### PR TITLE
fix: 英文标点后添加空格，逗号后不做首字母大写。add space after English punctuation and fix capitalization after comma

### DIFF
--- a/fireredasr2s/fireredasr2system.py
+++ b/fireredasr2s/fireredasr2system.py
@@ -176,6 +176,8 @@ class FireRedAsr2System:
 
         vad_segments_ms = [(int(s*1000), int(e*1000)) for s, e in vad_result["timestamps"]]
         text = "".join(s["text"] for s in sentences)
+        # Add space after English punctuation when followed by a letter
+        text = re.sub(r'([.,!?])\s*([a-zA-Z])', r'\1 \2', text)
 
         result = {
             "uttid": uttid,

--- a/fireredasr2s/fireredpunc/punc.py
+++ b/fireredasr2s/fireredpunc/punc.py
@@ -85,7 +85,15 @@ class FireRedPunc:
 
         new_punc_txts = []
         for txts in punc_txts:
-            new_txts = [(RuleBaedTxtFix.fix(txt[0]), txt[1], txt[2]) for txt in txts]
+            new_txts = []
+            for idx, txt in enumerate(txts):
+                # Only capitalize first letter after sentence-ending punctuation (.!?), not after comma
+                if idx == 0:
+                    cap = True
+                else:
+                    prev_text = new_txts[idx - 1][0]
+                    cap = bool(prev_text) and prev_text[-1] in '.!?。？！'
+                new_txts.append((RuleBaedTxtFix.fix(txt[0], capitalize_first=cap), txt[1], txt[2]))
             new_punc_txts.append(new_txts)
         punc_txts = new_punc_txts
 
@@ -321,7 +329,7 @@ class ModelIO:
 
 class RuleBaedTxtFix:
     @classmethod
-    def fix(cls, txt_ori):
+    def fix(cls, txt_ori, capitalize_first=True):
         txt = txt_ori.lower()
         # English Punc
         txt = re.sub(r"([a-z])，([a-z])", r"\1, \2", txt)
@@ -348,7 +356,7 @@ class RuleBaedTxtFix:
         txt = re.sub(" i've ", " I've ", txt)
         txt = re.sub(" i'll ", " I'll ", txt)
         # First English upper
-        if len(txt) > 0 and re.match("[a-z]", txt[0]):
+        if capitalize_first and len(txt) > 0 and re.match("[a-z]", txt[0]):
             txt = txt[0].upper() + txt[1:]
         txt = re.sub(r'([.!?。？！])\s+([a-z])', lambda m: f"{m.group(1)} {m.group(2).upper()}", txt)
 


### PR DESCRIPTION
Fix English text formatting in ASR output. Chinese text is not affected.

修复英文 ASR 输出的文本格式问题，不影响中文。

Before / 修复前: `Sentence one.Sentence two,With a comma.Sentence three.`
After / 修复后:  `Sentence one. Sentence two, with a comma. Sentence three.`

Changes / 修改:
- `fireredasr2system.py`: 英文标点(.,!?)后跟字母时自动加空格
- `punc.py`: 仅在句末标点(.!?)后大写首字母，逗号后不大写