### PR TITLE
Fixed ASR result is "%" when asr_use_half = 1

### DIFF
--- a/fireredasr2s/fireredasr2/asr.py
+++ b/fireredasr2s/fireredasr2/asr.py
@@ -82,7 +82,10 @@ class FireRedAsr2:
         logger.info(self.config)
         if self.config.use_gpu:
             if self.config.use_half:
-                self.model.half()
+                if torch.cuda.is_bf16_supported():
+                    self.model.bfloat16()
+                else:
+                    self.model.half()
             self.model.cuda()
             if self.elm:
                 self.elm.cuda()
@@ -104,7 +107,10 @@ class FireRedAsr2:
         if self.config.use_gpu:
             feats, lengths = feats.cuda(), lengths.cuda()
             if self.config.use_half:
-                feats = feats.half()
+                if torch.cuda.is_bf16_supported():
+                    feats = feats.bfloat16()
+                else:
+                    feats = feats.half()
 
         if self.asr_type == "aed":
             start_time = time.time()


### PR DESCRIPTION
Fixed an issue where the ASR module consistently outputs `%` when half-precision inference is enabled.

修复了 ASR 模块在启用半精度推理时，识别结果始终输出为 `%` 的问题。

#### Root Cause / 问题原因

When `--asr_use_half 1` is enabled, the previous implementation uses `float16` by default for inference. On some devices or during certain model computations, `float16` may cause numerical overflow, resulting in abnormal outputs.

原代码在启用 `--asr_use_half 1` 时，默认使用 `float16` 精度进行推理。在部分设备或特定模型计算过程中，`float16` 可能出现数值溢出，从而导致结果异常。

Replacing `float16` with `bfloat16` for half-precision inference resolves this issue and restores normal ASR output.

将半精度推理的数据类型由 `float16` 更换为 `bfloat16` 后，可以解决该问题，并恢复正常的 ASR 输出结果。

#### Reproduction / 问题复现

* Device: NVIDIA RTX 4090 24GB

* 设备：NVIDIA RTX 4090 24GB

* Script arguments / 相关脚本参数：
  - asr_type: llm
  - asr_batch_size: 1
  - asr_use_half: 1
```bash
asr_args="--asr_type llm --asr_model_dir $asr_model_dir --asr_use_gpu 1 --asr_use_half 1 \
--asr_batch_size 1 --beam_size 3 --nbest 1 \
--decode_max_len 0 --softmax_smoothing 1.25 --aed_length_penalty 0.6 \
--eos_penalty 1.0 --return_timestamp 1"
```

#### Output Before the Fix / 修复前输出结果

```text
2026-06-02 11:48:47,416 (fireredasr2system:75) INFO: ASR: [{'uttid': '01_s490_e4110', 'text': '%', 'rtf': '0.0762'}]
2026-06-02 11:48:47,579 (fireredasr2system:75) INFO: ASR: [{'uttid': '01_s4960_e17440', 'text': '%', 'rtf': '0.0077'}]
2026-06-02 11:48:47,732 (fireredasr2system:75) INFO: ASR: [{'uttid': '01_s17890_e23800', 'text': '%', 'rtf': '0.0166'}]
```

#### Output After the Fix / 修复后输出结果

```text
2026-06-02 11:56:49,857 (fireredasr2system:75) INFO: ASR: [{'uttid': '01_s490_e4110', 'text': '修咩逼修催狼来家集合', 'rtf': '0.2012'}]
2026-06-02 11:56:51,392 (fireredasr2system:75) INFO: ASR: [{'uttid': '01_s4960_e17440', 'text': '像我即款人咁咪使挖鬼气烦恼到尾说对唔住添不低不高这样子够多少钱啊', 'rtf': '0.1200'}]
2026-06-02 11:56:52,430 (fireredasr2system:75) INFO: ASR: [{'uttid': '01_s17890_e23800', 'text': '做嘅事我就是一个跟老师讲话便当菜嘅高大囡啊', 'rtf': '0.1677'}]
```
